### PR TITLE
fix(v0.1.2): lazy modelscope import, imported audio waveform, scrollable transitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Download the latest release from the [Releases](https://github.com/Ramendan/Baya
 
 ### Option A: Full package (recommended)
 
-Download **`BayanSynth-Studio-0.1.1-alpha-win-x64.7z`** (~1.5 GB).
+Download **`BayanSynth-Studio-0.1.2-win-x64.7z`** (~1.5 GB).
 
 This bundles **everything**: Electron app, embedded Python 3.11, PyTorch (CUDA 12.1), and all dependencies. No Python installation required.
 
@@ -22,7 +22,7 @@ This bundles **everything**: Electron app, embedded Python 3.11, PyTorch (CUDA 1
 
 ### Option B: Lightweight exe (for developers)
 
-Download **`BayanSynth Studio 0.1.1-alpha.exe`** (~68 MB).
+Download **`BayanSynth Studio 0.1.2.exe`** (~68 MB).
 
 This is just the Electron shell. It requires a Python 3.11 environment set up separately. See [Installation from source](#installation-from-source) below.
 

--- a/backend/server.py
+++ b/backend/server.py
@@ -172,7 +172,7 @@ class ArabicJSONResponse(JSONResponse):
         ).encode("utf-8")
 
 
-app = FastAPI(title="BayanSynth Studio API", version="0.1.1")
+app = FastAPI(title="BayanSynth Studio API", version="0.1.2")
 
 # Allow both the Vite dev server and the packaged Electron app (file:// origin)
 app.add_middleware(
@@ -432,7 +432,7 @@ async def status():
         "model_loading": _model_loading,
         "model_dir": str(storage),
         "voices_dir": VOICES_DIR,
-        "version": "0.1.1",
+        "version": "0.1.2",
     }
 
 

--- a/frontend/src/components/PropertiesPanel.jsx
+++ b/frontend/src/components/PropertiesPanel.jsx
@@ -287,146 +287,203 @@ export default function PropertiesPanel() {
         </div>
       </div>
 
-      {/* ═══════════ GROUP 1: Generation Properties ═══════════ */}
-      <div className="panel-group panel-group-gen">
-        <div className="panel-group-title gen-title">
-          Generation Properties
-          <button className="btn-revert" onClick={handleRevertGen} title="Revert to defaults">
-            <RotateCcw size={11} strokeWidth={2} />
-          </button>
-          {needsRegen && (
-            <span className="regen-badge" title="Text/voice/speed/seed changed — re-generate needed">
-              <AlertTriangle size={12} strokeWidth={2} /> Re-gen needed
-            </span>
+      {/* ═══════════ GROUP 1: Generation / Import Properties ═══════════ */}
+      {selectedNode.nodeType === 'imported' ? (
+        <div className="panel-group panel-group-import">
+          <div className="panel-group-title import-title">
+            Imported Audio
+          </div>
+
+          {/* Waveform preview */}
+          {selectedNode.waveformData && selectedNode.waveformData.length > 0 && (
+            <div className="panel-section">
+              <label>Waveform</label>
+              <canvas
+                ref={(canvas) => {
+                  if (!canvas || !selectedNode.waveformData) return;
+                  const ctx = canvas.getContext('2d');
+                  const w = canvas.width;
+                  const h = canvas.height;
+                  const data = selectedNode.waveformData;
+                  ctx.clearRect(0, 0, w, h);
+                  const step = w / data.length;
+                  const mid = h / 2;
+                  const amp = h * 0.4;
+                  ctx.fillStyle = trackColor + '33';
+                  ctx.strokeStyle = trackColor + 'aa';
+                  ctx.lineWidth = 1;
+                  ctx.beginPath();
+                  ctx.moveTo(0, mid);
+                  for (let i = 0; i < data.length; i++) {
+                    ctx.lineTo(i * step, mid - data[i] * amp);
+                  }
+                  for (let i = data.length - 1; i >= 0; i--) {
+                    ctx.lineTo(i * step, mid + data[i] * amp);
+                  }
+                  ctx.closePath();
+                  ctx.fill();
+                  ctx.stroke();
+                }}
+                width={200}
+                height={48}
+                className="import-waveform-canvas"
+              />
+            </div>
           )}
-        </div>
 
-        {/* Generate button (Item 5) */}
-        <div className="panel-section">
-          <button
-            className={`btn-generate ${generating ? 'generating' : ''}`}
-            onClick={handleGenerate}
-            disabled={generating || !selectedNode.text}
-            title="Generate audio for this node"
-          >
-            <Zap size={14} strokeWidth={2} />
-            {generating ? 'Generating...' : 'Generate'}
-          </button>
-        </div>
+          {/* Filename */}
+          <div className="panel-section">
+            <label>File</label>
+            <div className="import-filename">{selectedNode.text || '(unnamed)'}</div>
+          </div>
 
-        {/* Arabic Text (Item 4, 19: RTL + lang="ar") */}
-        <div className="panel-section">
-          <label>Arabic Text</label>
-          <textarea
-            rows={3}
-            value={selectedNode.text}
-            onChange={(e) => update({ text: e.target.value })}
-            onBlur={() => pushHistory()}
-            placeholder="اكتب النص العربي هنا..."
-            dir="rtl"
-            lang="ar"
-            className="arabic-input"
-          />
-          <div className="section-actions">
-            <button className="btn-haraka" onClick={handleTashkeel} title="Apply diacritics (auto-tashkeel)">
-              Tashkeel
+          {/* Duration info */}
+          <div className="panel-section">
+            <label>Original Duration</label>
+            <div className="import-filename">{(selectedNode.originalDuration || selectedNode.duration || 0).toFixed(2)}s</div>
+          </div>
+        </div>
+      ) : (
+        <div className="panel-group panel-group-gen">
+          <div className="panel-group-title gen-title">
+            Generation Properties
+            <button className="btn-revert" onClick={handleRevertGen} title="Revert to defaults">
+              <RotateCcw size={11} strokeWidth={2} />
             </button>
-            {!hasDiacritics(selectedNode.text) && (
-              <span className="warning-badge">No diacritics</span>
+            {needsRegen && (
+              <span className="regen-badge" title="Text/voice/speed/seed changed — re-generate needed">
+                <AlertTriangle size={12} strokeWidth={2} /> Re-gen needed
+              </span>
             )}
           </div>
-        </div>
 
-        {/* Phoneme Display */}
-        {phonemes && (
+          {/* Generate button (Item 5) */}
           <div className="panel-section">
-            <label>Phonemes</label>
-            <div className="phoneme-display">{phonemes}</div>
-          </div>
-        )}
-
-        {/* Voice */}
-        <div className="panel-section">
-          <label>Voice</label>
-          <select
-            value={selectedNode.voice || ''}
-            onChange={(e) => update({ voice: e.target.value || null })}
-          >
-            <option value="">Default</option>
-            {voices.map(v => (
-              <option key={v} value={v}>
-                {v.split(/[\\/]/).pop()}
-              </option>
-            ))}
-          </select>
-          <div className="section-actions">
-            <label className="btn-sm upload-btn">
-              <Upload size={12} strokeWidth={1.5} /> Upload
-              <input type="file" accept="audio/*" hidden onChange={handleVoiceUpload} />
-            </label>
             <button
-              className={`btn-sm ${recording ? 'recording' : ''}`}
-              onClick={recording ? stopRecording : startRecording}
+              className={`btn-generate ${generating ? 'generating' : ''}`}
+              onClick={handleGenerate}
+              disabled={generating || !selectedNode.text}
+              title="Generate audio for this node"
             >
-              <Mic size={12} strokeWidth={1.5} /> {recording ? 'Stop' : 'Rec'}
+              <Zap size={14} strokeWidth={2} />
+              {generating ? 'Generating...' : 'Generate'}
             </button>
           </div>
-        </div>
 
-        {/* Seed */}
-        <div className="panel-section">
-          <label>Seed</label>
-          <div className="seed-row">
-            <input
-              type="number"
-              value={selectedNode.seed}
-              onChange={(e) => update({ seed: parseInt(e.target.value) || 0 })}
+          {/* Arabic Text (Item 4, 19: RTL + lang="ar") */}
+          <div className="panel-section">
+            <label>Arabic Text</label>
+            <textarea
+              rows={3}
+              value={selectedNode.text}
+              onChange={(e) => update({ text: e.target.value })}
+              onBlur={() => pushHistory()}
+              placeholder="اكتب النص العربي هنا..."
+              dir="rtl"
+              lang="ar"
+              className="arabic-input"
             />
-            <button className="btn-dice" onClick={randomizeSeed} title="Random seed">
-              <Dice5 size={16} strokeWidth={1.5} />
-            </button>
-            <button
-              className="btn-dice"
-              onClick={handleAudition}
-              disabled={auditioning}
-              title="Audition seed (quick preview)"
+            <div className="section-actions">
+              <button className="btn-haraka" onClick={handleTashkeel} title="Apply diacritics (auto-tashkeel)">
+                Tashkeel
+              </button>
+              {!hasDiacritics(selectedNode.text) && (
+                <span className="warning-badge">No diacritics</span>
+              )}
+            </div>
+          </div>
+
+          {/* Phoneme Display */}
+          {phonemes && (
+            <div className="panel-section">
+              <label>Phonemes</label>
+              <div className="phoneme-display">{phonemes}</div>
+            </div>
+          )}
+
+          {/* Voice */}
+          <div className="panel-section">
+            <label>Voice</label>
+            <select
+              value={selectedNode.voice || ''}
+              onChange={(e) => update({ voice: e.target.value || null })}
             >
-              <Play size={14} strokeWidth={2} />
-            </button>
+              <option value="">Default</option>
+              {voices.map(v => (
+                <option key={v} value={v}>
+                  {v.split(/[\\/]/).pop()}
+                </option>
+              ))}
+            </select>
+            <div className="section-actions">
+              <label className="btn-sm upload-btn">
+                <Upload size={12} strokeWidth={1.5} /> Upload
+                <input type="file" accept="audio/*" hidden onChange={handleVoiceUpload} />
+              </label>
+              <button
+                className={`btn-sm ${recording ? 'recording' : ''}`}
+                onClick={recording ? stopRecording : startRecording}
+              >
+                <Mic size={12} strokeWidth={1.5} /> {recording ? 'Stop' : 'Rec'}
+              </button>
+            </div>
+          </div>
+
+          {/* Seed */}
+          <div className="panel-section">
+            <label>Seed</label>
+            <div className="seed-row">
+              <input
+                type="number"
+                value={selectedNode.seed}
+                onChange={(e) => update({ seed: parseInt(e.target.value) || 0 })}
+              />
+              <button className="btn-dice" onClick={randomizeSeed} title="Random seed">
+                <Dice5 size={16} strokeWidth={1.5} />
+              </button>
+              <button
+                className="btn-dice"
+                onClick={handleAudition}
+                disabled={auditioning}
+                title="Audition seed (quick preview)"
+              >
+                <Play size={14} strokeWidth={2} />
+              </button>
+            </div>
+          </div>
+
+          {/* Speed (generation-time property) */}
+          <div className="panel-section">
+            <label>Speed: {(selectedNode.speed || 1).toFixed(2)}x</label>
+            <input
+              type="range"
+              min="0.5"
+              max="2.0"
+              step="0.05"
+              value={selectedNode.speed || 1}
+              onChange={(e) => update({ speed: parseFloat(e.target.value) })}
+              style={{ accentColor: trackColor }}
+            />
+          </div>
+
+          {/* Speaking Style Instruction (Item 18) */}
+          <div className="panel-section">
+            <label>Speaking Style</label>
+            <textarea
+              rows={2}
+              value={selectedNode.instruct || ''}
+              onChange={(e) => update({ instruct: e.target.value })}
+              onBlur={() => pushHistory()}
+              placeholder="e.g. Speak cheerfully / اقرأ بصوت حماسي"
+              className="instruct-input"
+              dir="auto"
+            />
+            <div className="section-hint">
+              Controls tone, emotion, and pace. Leave empty for neutral.
+            </div>
           </div>
         </div>
-
-        {/* Speed (generation-time property) */}
-        <div className="panel-section">
-          <label>Speed: {(selectedNode.speed || 1).toFixed(2)}x</label>
-          <input
-            type="range"
-            min="0.5"
-            max="2.0"
-            step="0.05"
-            value={selectedNode.speed || 1}
-            onChange={(e) => update({ speed: parseFloat(e.target.value) })}
-            style={{ accentColor: trackColor }}
-          />
-        </div>
-
-        {/* Speaking Style Instruction (Item 18) */}
-        <div className="panel-section">
-          <label>Speaking Style</label>
-          <textarea
-            rows={2}
-            value={selectedNode.instruct || ''}
-            onChange={(e) => update({ instruct: e.target.value })}
-            onBlur={() => pushHistory()}
-            placeholder="e.g. Speak cheerfully / اقرأ بصوت حماسي"
-            className="instruct-input"
-            dir="auto"
-          />
-          <div className="section-hint">
-            Controls tone, emotion, and pace. Leave empty for neutral.
-          </div>
-        </div>
-      </div>
+      )}
 
       {/* ═══════════ GROUP 2: Audio Engine Properties ═══════════ */}
       <div className="panel-group panel-group-engine">

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -1166,6 +1166,29 @@ select {
   border-color: var(--warning-border);
 }
 
+.panel-group-import {
+  border-color: #00f0ff44;
+}
+
+.import-title {
+  color: var(--accent) !important;
+}
+
+.import-waveform-canvas {
+  width: 100%;
+  height: 48px;
+  border-radius: 4px;
+  background: var(--bg-secondary);
+  display: block;
+}
+
+.import-filename {
+  font-size: 11px;
+  color: var(--text-dim);
+  word-break: break-all;
+  padding: 4px 0;
+}
+
 .panel-group-engine {
   border-color: var(--accent-border);
 }
@@ -1984,12 +2007,15 @@ select {
    ═══════════════════════════════════════════════════════════════ */
 .transitions-lane {
   padding: 10px 12px;
+  overflow-y: auto;
+  max-height: 100%;
 }
 
 .transition-list {
   display: flex;
   flex-direction: column;
   gap: 8px;
+  overflow-y: auto;
 }
 
 .transition-item {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bayansynth-studio",
-  "version": "0.1.1-alpha",
+  "version": "0.1.2",
   "description": "BayanSynth Studio — Vocaloid-inspired Arabic TTS editor",
   "main": "electron/main.js",
   "private": true,


### PR DESCRIPTION
## Changes

### Bug fixes
- **Fix 'No module named modelscope' crash** on first-run download: made the import lazy (only needed when model_dir doesn't exist on disk). The packaged app always has models pre-downloaded, so modelscope is never needed.
- **Fix 'models_not_ready' error after restart**: same root cause as above. Once modelscope doesn't block the import chain, models load correctly on restart.

### UI improvements
- **Imported audio nodes** now show waveform preview and file info in the Properties panel (same visual style as TTS nodes)
- **Transitions tab** is now scrollable when many transitions are stacked

### Version bump
- 0.1.1-alpha -> 0.1.2
- README updated with 0.1.2 references